### PR TITLE
Update adapter.coffee

### DIFF
--- a/adapter.coffee
+++ b/adapter.coffee
@@ -92,7 +92,8 @@ decode = (s) ->
 
 room_for_message = (msg) ->
     if msg.type == 'private'
-        "pm-with:#{encode(msg.sender_email)}"
+        recipient_list =  (user.email for user in msg.display_recipient)
+        "pm-with:#{encode(recipient_list.join(','))}"
     else
         "stream:#{encode(msg.display_recipient)} topic:#{encode(msg.subject)}"
 

--- a/adapter.coffee
+++ b/adapter.coffee
@@ -92,7 +92,7 @@ decode = (s) ->
 
 room_for_message = (msg) ->
     if msg.type == 'private'
-        recipient_list =  (user.email for user in msg.display_recipient)
+        recipient_list = (user.email for user in msg.display_recipient)
         "pm-with:#{encode(recipient_list.join(','))}"
     else
         "stream:#{encode(msg.display_recipient)} topic:#{encode(msg.subject)}"


### PR DESCRIPTION
Change private chat behavior so that a private chat room can have multiple members and hubot can respond to everyone in the private chat. 

Instead of responding to msg.send_email  grab the display recipients and do a private message with all of them.