### PR TITLE
Fix user brain getting overwritten

### DIFF
--- a/adapter.coffee
+++ b/adapter.coffee
@@ -61,18 +61,24 @@ class Zulip extends Adapter
         @zulip.on 'message', (msg) =>
             return if msg.sender_email is @zulip.email
 
-            room = room_for_message(msg)
-            author = @robot.brain.userForId msg.sender_email,
-                name: msg.sender_full_name
-                email_address: msg.sender_email
-            author.room = room
+            author = this._author_for_message(msg)
 
             content = msg.content.replace(@mention_regex, '@$1')
             console.log(@mention_regex, content)
-            
+
             message = new TextMessage author, content, msg.id
             console.log "Received", message
             @receive(message)
+
+    _author_for_message: (msg) ->
+        author = @robot.brain.userForId msg.sender_email,
+            name: msg.sender_full_name
+            email_address: msg.sender_email
+        # Work around github/hubot#670 by setting room separately. If we pass it
+        # to userForId, it could delete the existing user from the brain.
+        author.room = room_for_message(msg)
+        author
+
 
 exports.use = (robot) ->
     new Zulip robot

--- a/adapter.coffee
+++ b/adapter.coffee
@@ -65,7 +65,7 @@ class Zulip extends Adapter
             author = @robot.brain.userForId msg.sender_email,
                 name: msg.sender_full_name
                 email_address: msg.sender_email
-                room: room
+            author.room = room
 
             content = msg.content.replace(@mention_regex, '@$1')
             console.log(@mention_regex, content)


### PR DESCRIPTION
* This works around github/hubot#670
* hubot's userForId checks if the current room is different than the one that was last recorded for the user; if it's different, it overwrites the entire record for that user.

I originally expected the hubot bug to be fixed quickly, but that's 3 years old now.